### PR TITLE
Added non semantic dependency version

### DIFF
--- a/eco.gemspec
+++ b/eco.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   ]
 
   s.add_dependency "coffee-script"
-  s.add_dependency "eco-source"
+  s.add_dependency "eco-source","1.1.0.rc.1"
   s.add_dependency "execjs"
 end


### PR DESCRIPTION
attempt to resolve #1 specifying the pre dependency resolves the dependency issues for gems which do not follow [semantic versioning 2.0.0](http://semver.org/spec/v2.0.0.html)
